### PR TITLE
Fix cancelAllCommands canceling for all peripherals

### DIFF
--- a/RZBluetooth/RZBPeripheral.m
+++ b/RZBluetooth/RZBPeripheral.m
@@ -130,7 +130,10 @@
                                          code:RZBluetoothConnectionCancelled
                                      userInfo:@{}];
 
-    for (RZBCommand *command in [self.dispatch commands]) {
+    RZBUUIDPath *path = RZBUUIDP(self.identifier);
+    NSArray *commands = [self.dispatch commandsOfClass:nil matchingUUIDPath:path];
+
+    for (RZBCommand *command in commands) {
         [self.dispatch completeCommand:command
                             withObject:nil error:error];
     }


### PR DESCRIPTION
Fixes #99. cancelAllCommands is canceling for all peripherals.
Fix to only do so for the current peripheral.